### PR TITLE
Update removeComponent method

### DIFF
--- a/src/componentMask.h
+++ b/src/componentMask.h
@@ -20,7 +20,7 @@ namespace nomad {
 
     template<typename ComponentType>
     void removeComponent() {
-      mask ^= (1 << GetComponentFamily<ComponentType>());
+      mask &= ~(1 << GetComponentFamily<ComponentType>());
     }
 
     bool isNewMatch(ComponentMask oldMask, ComponentMask systemMask);


### PR DESCRIPTION
RemoveComponent method is actually clearing the bits. Using ^= operator will set the bits unexpectedly.